### PR TITLE
Update install URLs to use CDN endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ vectorize-iris document.pdf
 
 **CLI:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vectorize-io/vectorize-iris/refs/heads/main/install.sh | sh
+curl -fsSL https://get-iris.vectorize.io | sh
 ```
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -146,7 +146,7 @@ npm install vectorize-iris
 
 ### Rust CLI (via install script)
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vectorize-io/vectorize-iris/refs/heads/main/install.sh | sh
+curl -fsSL https://get-iris.vectorize.io | sh
 ```
 
 Or download binaries directly from the [GitHub Releases page](https://github.com/YOUR_USERNAME/vectorize-iris/releases).


### PR DESCRIPTION
Replace GitHub raw URLs with the new branded CDN endpoint get-iris.vectorize.io for cleaner, more professional install experience.

Changes:
- README.md: Update CLI installation command
- RELEASE.md: Update installation documentation

The new endpoint is backed by CloudFront and redirects to the GitHub install script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)